### PR TITLE
feat: use local waitlist image paths

### DIFF
--- a/src/app/waitlist/page.tsx
+++ b/src/app/waitlist/page.tsx
@@ -9,11 +9,11 @@ export default function WaitlistPage() {
   const [joining, setJoining] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const featureImages = [
-      "https://iili.io/FyH8Nsf.png",
-        "https://iili.io/FyH8VRt.png",
-        "https://iili.io/FyH8WOX.png",
-        "https://iili.io/FyH8MJI.png",
-        "https://iili.io/FyH8EUN.png",
+    "/waitlist/feature1.png",
+    "/waitlist/feature2.png",
+    "/waitlist/feature3.png",
+    "/waitlist/feature4.png",
+    "/waitlist/feature5.png",
   ];
   const [idx, setIdx] = useState(0);
   const [waitlistCount, setWaitlistCount] = useState<number | null>(null);


### PR DESCRIPTION
## Summary
- reference waitlist screenshots from local `/waitlist` paths
- add placeholder directory for waitlist images

## Testing
- `npm run lint` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68b92ef525a0832c8aef29e0a4d860b0