### PR TITLE
Use Supabase count for waitlist size

### DIFF
--- a/src/app/waitlist/page.tsx
+++ b/src/app/waitlist/page.tsx
@@ -21,12 +21,18 @@ export default function WaitlistPage() {
   useEffect(() => {
     async function fetchWaitlistCount() {
       const sb = getSupabaseBrowser();
-      const { data, error } = await sb.from("profiles").select("*");
+      const { count, error } = await sb
+        .from("profiles")
+        .select("*", { count: "exact", head: true });
       if (error) {
         console.error("Error fetching waitlist count:", error);
         return;
       }
-      setWaitlistCount(data.length);
+      if (count !== null) {
+        setWaitlistCount(count);
+      } else {
+        setWaitlistCount(null);
+      }
     }
     fetchWaitlistCount();
   }, []);


### PR DESCRIPTION
## Summary
- query only count for waitlist profiles and handle possible null results

## Testing
- `npm test` *(fails: command not found)*
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9542edb54832cb0d8aebd910603f1