### PR TITLE
Secure cross-function calls

### DIFF
--- a/supabase/functions/ingest-forum-thread/index.ts
+++ b/supabase/functions/ingest-forum-thread/index.ts
@@ -13,6 +13,7 @@ const SERVICE_ROLE  = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
 const SHARED_BEARER = Deno.env.get("INGEST_SHARED_BEARER") || "";
 const POST_CONTRACT_FUNCTION_PATH = Deno.env.get("POST_CONTRACT_FUNCTION_PATH") || "/functions/v1/post-contract-to-discord";
 const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY") || ""; // needed for Edge→Edge call through the gateway
+const POST_CONTRACT_SHARED_SECRET = Deno.env.get("POST_CONTRACT_SHARED_SECRET") || "";
 
 const sb = createClient(SUPABASE_URL, SERVICE_ROLE, { auth: { persistSession: false } });
 
@@ -208,8 +209,8 @@ serve(async (req) => {
         headers: {
           "Content-Type": "application/json",
           "apikey": SUPABASE_ANON_KEY, // required by Supabase gateway even with no-verify-jwt
-          // Optionally also send Authorization with anon:
-          // "Authorization": `Bearer ${SUPABASE_ANON_KEY}`,
+          "Authorization": `Bearer ${SUPABASE_ANON_KEY}`,
+          ...(POST_CONTRACT_SHARED_SECRET ? { "x-shared-secret": POST_CONTRACT_SHARED_SECRET } : {}),
         },
         body: JSON.stringify(payload),
       });

--- a/supabase/functions/post-contract-to-discord/index.ts
+++ b/supabase/functions/post-contract-to-discord/index.ts
@@ -13,6 +13,8 @@ const FORUM_CHANNEL_ID = Deno.env.get("DISCORD_FORUM_CHANNEL_ID"); // the forum 
 const SITE_ORIGIN = (Deno.env.get("PUBLIC_SITE_ORIGIN") ?? "").replace(/\/$/, "");
 // optional: comma-separated forum tag IDs (snowflakes)
 const FORUM_TAG_IDS = (Deno.env.get("DISCORD_FORUM_TAG_IDS") ?? "").split(",").map((s)=>s.trim()).filter(Boolean);
+const ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY") || "";
+const SHARED_SECRET = Deno.env.get("POST_CONTRACT_SHARED_SECRET") || "";
 const sb = createClient(SUPABASE_URL, SERVICE_ROLE, {
   auth: {
     persistSession: false
@@ -26,6 +28,16 @@ serve(async (req)=>{
     status: 405,
     headers: CORS
   });
+  const authHeader = req.headers.get("authorization") || "";
+  if (!authHeader.startsWith("Bearer ") || authHeader.slice(7) !== ANON_KEY) {
+    return new Response("Unauthorized", { status: 401, headers: CORS });
+  }
+  if (SHARED_SECRET) {
+    const provided = req.headers.get("x-shared-secret") || "";
+    if (provided !== SHARED_SECRET) {
+      return new Response("Forbidden", { status: 403, headers: CORS });
+    }
+  }
   try {
     const { contract_id } = await req.json();
     if (!contract_id) return new Response("Missing contract_id", {


### PR DESCRIPTION
## Summary
- enforce Authorization Bearer token and optional shared secret in post-contract-to-discord edge function
- send Authorization header (and optional shared secret) when ingesting forum threads

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4a01f02c8832c96a18f3f7e2dd27e