### PR TITLE
feat: restrict allowed origins per environment

### DIFF
--- a/supabase/functions/submit-application/index.ts
+++ b/supabase/functions/submit-application/index.ts
@@ -3,11 +3,12 @@
 import { serve } from "https://deno.land/std/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
-const ALLOWED_ORIGINS = new Set<string>([
-  "https://civhub.net",
-  "http://localhost:3000",
-  "http://127.0.0.1:3000",
-]);
+const PROD_ORIGINS = ["https://civhub.net"];
+const DEV_ORIGINS = ["http://localhost:3000", "http://127.0.0.1:3000"];
+const ENV = Deno.env.get("NODE_ENV") === "development" ? "development" : "production";
+const ALLOWED_ORIGINS = new Set<string>(
+  ENV === "development" ? [...PROD_ORIGINS, ...DEV_ORIGINS] : PROD_ORIGINS,
+);
 
 function corsHeaders(origin: string | null) {
   const allowOrigin = origin && ALLOWED_ORIGINS.has(origin) ? origin : "https://civhub.net";

--- a/supabase/functions/verify-guild/index.ts
+++ b/supabase/functions/verify-guild/index.ts
@@ -5,7 +5,10 @@ import jwt from "npm:jsonwebtoken@9.0.2";
 const DISCORD_BOT_TOKEN = Deno.env.get("DISCORD_BOT_TOKEN")!;
 const DISCORD_GUILD_ID = Deno.env.get("DISCORD_GUILD_ID")!;
 const IN_GUILD_JWT_SECRET = Deno.env.get("IN_GUILD_JWT_SECRET") || crypto.randomUUID();
-const ALLOWED_ORIGINS = (Deno.env.get("ALLOWED_ORIGINS") || "https://civhub.net,http://localhost:3000,http://127.0.0.1:3000").split(",").map((s) => s.trim());
+const PROD_ORIGINS = ["https://civhub.net"];
+const DEV_ORIGINS = ["http://localhost:3000", "http://127.0.0.1:3000"];
+const ENV = Deno.env.get("NODE_ENV") === "development" ? "development" : "production";
+const ALLOWED_ORIGINS = ENV === "development" ? [...PROD_ORIGINS, ...DEV_ORIGINS] : PROD_ORIGINS;
 
 function corsHeaders(origin: string | null) {
   const allowOrigin = origin && ALLOWED_ORIGINS.includes(origin) ? origin : "*";


### PR DESCRIPTION
## Summary
- limit allowed origins to production domains by default
- expand allowed origins for dev when NODE_ENV=development

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4a0637560832c8e87317d147b21a2